### PR TITLE
README: brief mode should not be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ You can generate trace2 event data for a Git command as follows:
 ```
 GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
         GIT_TRACE2_EVENT_DEPTH=100 \
+        GIT_TRACE2_EVENT_BRIEF=false \
         git <arguments>
 ```
 


### PR DESCRIPTION
Update the README to require full rather than brief event output.

If GIT_TRACE2_EVENT_BRIEF is set, the Trace2 event lines will not have
"file", "line", and "time" fields.  The "time" field only appears in
the "version" and "atexit" events.

This causes the computation in rl.on() yields NaN for obj.ms_time.
This causes all of the horizontal scaling to fail.

It is not sufficient to switch to obj.t_abs because it is relative
to a single command rather than globally.  This would be an issue
when there are nested commands in the trace.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>