### PR TITLE
add xmlns to allow browser rendering

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -159,7 +159,7 @@ rl.on('close', function() {
 
         const row_height = 50;
         const height = 70 + row_height * (max_depth + 1);
-        console.log("<svg width=\"" + width + "\" height=\"" + height + "\">");
+        console.log("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" + width + "\" height=\"" + height + "\">");
 
         console.log("<style>");
         console.log(".box { font: 16px sans-serif; }");


### PR DESCRIPTION
without this i would see 

<img width="719" alt="image" src="https://github.com/derrickstolee/trace2-flamechart/assets/39191/a1d0c216-6807-4da2-9705-7efe3bae5038">


and even if viewed in an html doc it'd be broken:

<img width="249" alt="image" src="https://github.com/derrickstolee/trace2-flamechart/assets/39191/638be7a8-239e-4dc1-ac27-7b9b1e182c88">


adding the `xmlns` fixes all that. 